### PR TITLE
Use futures-core instead of futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ description = "Conversion from Future to Stream"
 repository = "https://github.com/ivan770/enstream"
 
 [dependencies]
-futures-util = { version = "0.3.21", default-features = false }
+futures-core = { version = "0.3.21", default-features = false }
 pin-project = "1.0.10"
 pinned-aliasable = "0.1.3"
+
+[dev-dependencies]
+futures-util = "0.3.21"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! assert_eq!(stream.next().now_or_never().flatten(), Some("test"));
 //! ```
 //!
-//! [`Stream`]: futures_util::stream::Stream
+//! [`Stream`]: futures_core::stream::Stream
 
 #![no_std]
 #![feature(generic_associated_types)]
@@ -58,14 +58,12 @@ use core::{
     task::{Context, Poll},
 };
 
-use futures_util::stream::{FusedStream, Stream};
+use futures_core::stream::{FusedStream, Stream};
 use pin_project::pin_project;
 use pinned_aliasable::Aliasable;
 use yield_now::YieldNow;
 
 /// [`Future`] generator that can be converted to [`Stream`].
-///
-/// [`Stream`]: futures_util::stream::Stream
 pub trait HandlerFn<'scope, T: 'scope> {
     type Fut<'yielder>: Future<Output = ()> + 'yielder
     where
@@ -78,16 +76,12 @@ pub trait HandlerFn<'scope, T: 'scope> {
     ///
     /// However, for those cases [`HandlerFn`] provides you with `'scope` lifetime,
     /// which is required to outlive `'yielder`.
-    ///
-    /// [`Stream`]: futures_util::stream::Stream
     fn call<'yielder>(self, yielder: Yielder<'yielder, T>) -> Self::Fut<'yielder>
     where
         'scope: 'yielder;
 }
 
 /// [`Stream`] item yielder.
-///
-/// [`Stream`]: futures_util::stream::Stream
 pub struct Yielder<'a, T>(NonNull<Option<T>>, PhantomData<&'a mut T>);
 
 impl<'a, T> Yielder<'a, T> {
@@ -216,8 +210,6 @@ unsafe impl<T: Send, G: Send, F: Send> Send for Enstream<T, G, F> {}
 unsafe impl<T: Send, G: Send, F: Send> Sync for Enstream<T, G, F> {}
 
 /// Create new [`Stream`] from the provided [`HandlerFn`].
-///
-/// [`Stream`]: futures_util::stream::Stream
 pub fn enstream<'scope, T: 'scope, G: 'scope>(generator: G) -> impl FusedStream<Item = T> + 'scope
 where
     G: HandlerFn<'scope, T>,


### PR DESCRIPTION
[`futures-core`](https://docs.rs/futures-core) is the library that actually defines the `Stream` trait, so to reduce dependencies we can depend on that instead.