### PR TITLE
Use `pin-project-lite` instead of `pin-project`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ivan770/enstream"
 
 [dependencies]
 futures-core = { version = "0.3.21", default-features = false }
-pin-project = "1.0.10"
+pin-project-lite = "0.2.9"
 pinned-aliasable = "0.1.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This reduces dependencies and can improve compile times by avoiding `syn`, `quote` and `proc-macro2`.